### PR TITLE
Undid the previous setStrRef change.

### DIFF
--- a/vulkan-api/src/Graphics/Vulkan/Marshal/Create.hs
+++ b/vulkan-api/src/Graphics/Vulkan/Marshal/Create.hs
@@ -171,15 +171,11 @@ setStr v = CreateVkStruct $ \p ->
 --
 --   This function also attaches a reliable finalizer to the vulkan struct,
 --    so that the allocated memory is freed when the structure is GCed.
---
---   This function writes null pointer if used with an empty string.
 setStrRef :: forall fname x
            . ( CanWriteField fname x
              , FieldType fname x ~ CString
              )
           => String -> CreateVkStruct x '[fname] ()
-setStrRef "" = CreateVkStruct $ \p ->
-  (,) ([],[]) <$> writeField @fname @x p nullPtr
 setStrRef v = CreateVkStruct $ \p -> do
   sPtr <- newCString v
   (,) ([coerce sPtr],[]) <$> writeField @fname @x p sPtr


### PR DESCRIPTION
Turns out there *are* cases where it would be useful to provide an empty string rather than null in Vulkan, such as: https://khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkDebugMarkerObjectNameInfoEXT.html.