### PR TITLE
ghc 8.10 compatibility: impredicativity and proxy#

### DIFF
--- a/vulkan-api/src/Graphics/Vulkan/Marshal/Internal.hs
+++ b/vulkan-api/src/Graphics/Vulkan/Marshal/Internal.hs
@@ -183,7 +183,7 @@ class VulkanFields (ms :: [FieldMeta]) where
                     -> a -> a
 
 instance VulkanFields '[] where
-    withField = error "VulkanFields.withField: unreachable code (no such field guarded by type family)."
+    withField _ _ _ = error "VulkanFields.withField: unreachable code (no such field guarded by type family)."
     enumerateFields _ = id
 
 instance (VulkanField m, VulkanFields ms) => VulkanFields (m ': ms) where
@@ -198,7 +198,7 @@ instance (VulkanField m, VulkanFields ms) => VulkanFields (m ': ms) where
         proofms :: Proxy# fname -> Proxy# errMsg
                 -> (GetFieldMeta errMsg fname ms :~: GetFieldMeta errMsg fname (m : ms))
         proofms _ = unsafeCoerce Refl
-    enumerateFields k = k (proxy# @_ @m) . enumerateFields @ms k
+    enumerateFields k = k (proxy# :: Proxy# m) . enumerateFields @ms k
 
 
 class VulkanFields (SFields m)

--- a/vulkan-examples/Lib/Utils/TH.hs
+++ b/vulkan-examples/Lib/Utils/TH.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE TemplateHaskell #-}
 module Lib.Utils.TH
     ( compileGLSL
@@ -77,9 +78,12 @@ compileGLSL fpath = do
           (++ replicate (contentSize - hasRead) 0) <$> peekArray hasRead ptr
 
 
-
-    return $ TupE [ LitE . IntegerL . fromIntegral $ length contents
-                  , AppE (ConE 'Ptr) (LitE $ StringPrimL contents) ]
+    return $ TupE
+#if MIN_VERSION_template_haskell(2,16,0)
+           $ map Just
+#endif
+           [ LitE . IntegerL . fromIntegral $ length contents
+           , AppE (ConE 'Ptr) (LitE $ StringPrimL contents) ]
 
 
 reportGlslMsgs :: String -> Q ()


### PR DESCRIPTION
This addresses some GHC 8.10 changes:
  * [Reject nested predicates in impredicativity checking](https://gitlab.haskell.org/ghc/ghc/merge_requests/575) (see also the [GHC 8.10 migration guide](https://gitlab.haskell.org/ghc/ghc/wikis/Migration/8.10#ghc-is-pickier-about-impredicative-uses-of-constraints)).
  * [Clean up Proxy# infelicities](https://gitlab.haskell.org/ghc/ghc/merge_requests/334).

With these changes, the library builds successfully with the current version of GHC head.    

These changes retain compatibility with previous versions of GHC.