### PR TITLE
triangles: Fixed TH for GHC 8.10

### DIFF
--- a/vulkan-triangles/app/Main.hs
+++ b/vulkan-triangles/app/Main.hs
@@ -3,5 +3,6 @@ module Main (main) where
 import Lib
 
 main :: IO ()
--- demos: Squares or Chalet. Chalet needs obj and texture files from https://vulkan-tutorial.com/Loading_models
+-- demos: Squares or VikingRoom. VikingRoom needs obj and texture files from https://vulkan-tutorial.com/Loading_models
+-- (Chalet also works, for the files from older versions of the vulkan tutorial)
 main = runVulkanProgram Squares

--- a/vulkan-triangles/src/Lib/Vulkan/Shader/TH.hs
+++ b/vulkan-triangles/src/Lib/Vulkan/Shader/TH.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP #-}
 module Lib.Vulkan.Shader.TH
     ( compileGLSL
     ) where
@@ -78,8 +79,13 @@ compileGLSL fpath = do
 
 
 
+#if __GLASGOW_HASKELL__ >= 810
     return $ TupE [ Just . LitE . IntegerL . fromIntegral $ length contents
                   , Just $ AppE (ConE 'Ptr) (LitE $ StringPrimL contents) ]
+#else
+    return $ TupE [ LitE . IntegerL . fromIntegral $ length contents
+                  , AppE (ConE 'Ptr) (LitE $ StringPrimL contents) ]
+#endif
 
 
 reportGlslMsgs :: String -> Q ()

--- a/vulkan-triangles/src/Lib/Vulkan/Shader/TH.hs
+++ b/vulkan-triangles/src/Lib/Vulkan/Shader/TH.hs
@@ -78,8 +78,8 @@ compileGLSL fpath = do
 
 
 
-    return $ TupE [ LitE . IntegerL . fromIntegral $ length contents
-                  , AppE (ConE 'Ptr) (LitE $ StringPrimL contents) ]
+    return $ TupE [ Just . LitE . IntegerL . fromIntegral $ length contents
+                  , Just $ AppE (ConE 'Ptr) (LitE $ StringPrimL contents) ]
 
 
 reportGlslMsgs :: String -> Q ()


### PR DESCRIPTION
This is a breaking change from Language.Haskell.TH. Will not work with
GHC 8.8 anymore.

This either needs conditional compilation or the cabal file should require GHC >=8.10, or to be more explicit template-haskell >=2.16.0.0